### PR TITLE
Add rule to clean workflow output

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -53,6 +53,11 @@ subworkflow pypsaearth:
         "./config.yaml"
 
 
+rule clean:
+    run:
+        shell("snakemake -j 1 solve_network --delete-all-output")
+
+
 rule build_demand:
     input:
         sample_profile=PROFILE,


### PR DESCRIPTION
# Closes #14 

## Changes proposed in this Pull Request

Added a simple rule to remove output of the workflow which may be useful to avoid messing-up data for different configurations.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
