### PR TITLE
Fix hardo-coding in calculation for location of a microgrid center

### DIFF
--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -79,8 +79,8 @@ def create_bus_regions(microgrids_list, output_path):
         microgrid_names.append(microgrid_name)
 
         # Centre of the rectangle of the microgrid
-        x = 7.499138
-        y = 9.106406
+        x = (values[0] + values[1]) / 2
+        y = (values[2] + values[3]) / 2
         microgrid_x.append(x)
         microgrid_y.append(y)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Replace the hard-coded values for `x` and `y` coordinates of a microgrid center with a value calculated using actual microgrid coordinates.

## Checklist

- [ x I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
