### PR TITLE
Add an option to disable subworkflow

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -8,6 +8,7 @@ from snakemake.io import expand
 from build_test_configs import create_test_config
 from os.path import normpath, exists, isdir
 from shutil import copyfile
+from _helpers import create_country_list
 
 import sys
 
@@ -32,6 +33,8 @@ if "config" not in globals() or not config:  # skip when used as sub-workflow
         # copyfile("config.distribution.yaml", "config.yaml")
 
     configfile: "config.yaml"
+
+config["countries"] = create_country_list(config["countries"])    
 
 
 ATLITE_NPROCESSES = config["atlite"].get("nprocesses", 5)

--- a/Snakefile
+++ b/Snakefile
@@ -21,6 +21,8 @@ HTTP = HTTPRemoteProvider()
 COSTS = "data/costs.csv"
 PROFILE = "data/sample_profile.csv"
 
+PYPSAEARTH_FOLDER = "pypsa-earth"
+
 if "config" not in globals() or not config:  # skip when used as sub-workflow
     if not exists("config.yaml"):
         # prepare pypsa-earth config
@@ -44,13 +46,21 @@ wildcard_constraints:
     discountrate="[-+a-zA-Z0-9\.\s]*",
 
 
-subworkflow pypsaearth:
-    workdir:
-        "./pypsa-earth"
-    snakefile:
-        "./pypsa-earth/Snakefile"
-    configfile:
-        "./config.yaml"
+if not config.get("disable_subworkflow", False):
+
+    subworkflow pypsaearth:
+        workdir:
+            PYPSAEARTH_FOLDER
+        snakefile:
+            PYPSAEARTH_FOLDER + "/Snakefile"
+        configfile:
+            "./config.pypsa-earth.yaml"
+
+
+if config.get("disable_subworkflow", False):
+
+    def pypsaearth(path):
+        return PYPSAEARTH_FOLDER + "/" + path
 
 
 rule clean:

--- a/config.distribution.yaml
+++ b/config.distribution.yaml
@@ -10,6 +10,9 @@ logging:
   level: INFO
   format: "%(levelname)s:%(name)s:%(message)s"
 
+# option to disable the subworkflow to ease the analyses
+disable_subworkflow: false
+
 scenario:
   simpl: ['']
   ll: ['copt']


### PR DESCRIPTION
Closes #35, #20 and (hopefully) #32

## Changes proposed in this Pull Request

Copy-pasted [changes](https://github.com/pypsa-meets-earth/pypsa-earth-sec/pull/285/files) from PyPSA-Earth-Sec intended to add an option for switching-off the sub-workflows replacing them by a direct path definitions.

Tested on mac, seems to work properly and make life much easier. @davide-f thanks a lot for the proposed solution!

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
