### PR TITLE
Add a license consent to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 
 ## Checklist
 
-- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
+- [ ] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
 - [ ] I tested my contribution locally and it seems to work fine.
 - [ ] Code and workflow changes are sufficiently documented.
 - [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 
 ## Checklist
 
+- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
 - [ ] I tested my contribution locally and it seems to work fine.
 - [ ] Code and workflow changes are sufficiently documented.
 - [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)


### PR DESCRIPTION
# Closes #24.

## Changes proposed in this Pull Request

Add a consent to the GPLv3 for PRs. I suspect, there may be not crucial as the project is anyway licensed under GPLv3, but may be nice to have, anyway.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
