### PR TITLE
building data download with an overpass query v2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -159,9 +159,7 @@ rule create_network:
         "scripts/create_network.py"
 
 
-if config["enable"].get("download_osm_buildings", True) or config["enable"].get(
-    "download_osm_buildings_overpass", True
-):
+if config["enable"].get("download_osm_buildings", True):
 
     rule download_osm_data:
         output:

--- a/config.distribution.yaml
+++ b/config.distribution.yaml
@@ -18,7 +18,7 @@ enable:
   retrieve_cost_data: true
   download_osm_data: true
   download_osm_buildings: false
-  download_osm_buildings_overpass: false
+  download_osm_method: overpass # or earth_osm
   # If "build_cutout" : true # requires cds API key
   # https://cds.climate.copernicus.eu/api-how-to
   # More information

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     countries = snakemake.config["countries"]
     country_list = country_list_to_geofk(countries)
 
-    if snakemake.config["enable"]["download_osm_buildings"] == True:
+    if snakemake.config["enable"]["download_osm_method"] == "earth_osm":
         eo.save_osm_data(
             region_list=country_list,
             primary_name="building",
@@ -145,7 +145,7 @@ if __name__ == "__main__":
                 logger.info(f"Move {old_file[0]} to {new_file_name}")
                 shutil.move(old_file[0], new_file_name)
 
-    if snakemake.config["enable"]["download_osm_buildings_overpass"] == True:
+    elif snakemake.config["enable"]["download_osm_method"] == "overpass":
         microgrids_list = snakemake.config["microgrids_list"]
         features = "building"
         overpass_url = "https://overpass-api.de/api/interpreter"


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
The improvements are:
- Overpass query is modified to download multiple microgrids building data
- An option is presented to the user for downloading building data with earth osm package or overpass query in the config file.
- Snakefile is modified to resolve the issue when **download_osm_buildings_overpass** flag set to **true** and **download_osm_buildings** set to **false**.


## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
