### PR TITLE
fix attempt to deleted lines in the clean_osm script

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -84,7 +84,7 @@ jobs:
         rm -rf results
         rm -rf networks
         cp -rf test/config.distribution.test_MA.yaml configs/config.distribution.yaml
-        cp -rf test/config.pypsa-earth_MA.yaml config.pypsa-earth.yaml
+        cp -rf test/config.pypsa-earth_MA.yaml configs/config.pypsa-earth.yaml
         snakemake --cores all dist_solve_network --configfile configs/config.distribution.yaml --forceall
 
         # - name: Test plotting and summaries

--- a/rules/pypsa_distribution.smk
+++ b/rules/pypsa_distribution.smk
@@ -158,7 +158,7 @@ if config.get("mode") == "brown_field":
             substations="resources/" + RDIR + "osm/raw/all_raw_substations.geojson",
             country_shapes="resources/shapes/microgrid_shapes.geojson",
             offshore_shapes=pypsaearth("resources/shapes/offshore_shapes.geojson"),
-            africa_shape=pypsaearth("resources/shapes/africa_shape.geojson"),
+            africa_shape="resources/" + RDIR + "shapes/microgrid_shapes.geojson",
         output:
             generators="resources/" + RDIR + "osm/clean/all_clean_generators.geojson",
             generators_csv="resources/" + RDIR + "osm/clean/all_clean_generators.csv",


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

Hello,

In clean_osm_data script, lines outside the africa_shape multipolygon are filtered and returns no line. In the hope of solving the issue for microgrid studies I have used microgrid_shapes as input in the snakefile not the africa_shape and passed it to clean_osm_data script. The previous case should have also worked for Morocco but there may be problem with build_shapes script for brown_field mode. 
I should also mention that the africa_shape input for clean_osm_data is deprecated in PyPSA-Earth and extended_country_shape name is used instead. But the filter inside the clean_osm_data is still the same.

For year reference: https://github.com/pypsa-meets-earth/pypsa-earth/blob/60f9f9776f3642928c73d97c290d17368a1e6fde/scripts/clean_osm_data.py#L992


## Checklist

- [x] I consent to the release of this PR's code under the GPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to the main environment at [PyPSA-Earth repository](https://github.com/pypsa-meets-earth/pypsa-earth)
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
